### PR TITLE
Remove JSON syntax hardcoded path, get syntax by name

### DIFF
--- a/indent_x/commands/format_json_command.py
+++ b/indent_x/commands/format_json_command.py
@@ -23,6 +23,6 @@ class FormatJsonCommand(FormatCommandBase):
         formatter = JsonFormatter(reader, {'force_property_quotes': True, 'quote_char': '"', 'normalize_strings': True, 'indent_character': options['indent_character']})
         formattedText = formatter.format()
 
-        self.view.assign_syntax(sublime.find_syntax_by_name('JSON'))
+        self.view.assign_syntax(self.sublime.find_syntax_by_name('JSON')[0])
 
         return formattedText

--- a/indent_x/commands/format_json_command.py
+++ b/indent_x/commands/format_json_command.py
@@ -23,6 +23,6 @@ class FormatJsonCommand(FormatCommandBase):
         formatter = JsonFormatter(reader, {'force_property_quotes': True, 'quote_char': '"', 'normalize_strings': True, 'indent_character': options['indent_character']})
         formattedText = formatter.format()
 
-        self.view.set_syntax_file('Packages/JavaScript/JSON.tmLanguage')
+        self.view.assign_syntax(sublime.find_syntax_by_name('JSON'))
 
         return formattedText


### PR DESCRIPTION
`Packages/JavaScript/JSON.tmLanguage` is no longer available as a part of ST. Instead, get (current) syntax for `JSON` files and apply